### PR TITLE
Update readme to not recommend Google Domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Self hosting Beeper is possible, but not an easy task right now. It requires exp
 </aside>
 
 1. **Purchase a domain**
-    1. We recommend Google Domains
+    1. We recommend Cloudflare
     2. Insert this domain (eg `selfhostbeeper.com`) wherever `<insert_domain>` is shown in these instructions.
 2. **Select a hosting provider**
     1. We recommend a 2GB RAM 50GB disk Digital Ocean Droplet


### PR DESCRIPTION
Google domains is being sold to Squarespace and wont exist as it does today.

I made an edit to suggest Cloudflare, but happy to update to anything else that the maintainers think is a good alternative.